### PR TITLE
OKD-89: feature: creates a base folder to be used on ArgoCD

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - pipelines/
-  - buildconfigs/release-worker/
-  - tasks/
-  - templates/
+  - ../pipelines/
+  - ../buildconfigs/release-worker/
+  - ../tasks/
+  - ../templates/
 namespace: okd-team


### PR DESCRIPTION
ArgoCD requires the kustomization.yaml file is inside of a folder in the github repo.