### PR TITLE
fix: the param for the private key was wrong

### DIFF
--- a/base/tekton.dev/tasks/get-github-access-token.yaml
+++ b/base/tekton.dev/tasks/get-github-access-token.yaml
@@ -24,7 +24,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: $(params.githubapp-secret-name)
-              key: private.key
+              key: githubapp-private-key
       script: |
         #!/usr/bin/env bash
 


### PR DESCRIPTION
The key `private.key` inside of the secret `okd-githubapp-auth` was wrong because it was changed for `githubapp-private-key` in PR #10 