### PR TITLE
fix: the key for the prow secret

### DIFF
--- a/base/tekton.dev/tasks/update-release-channel.yaml
+++ b/base/tekton.dev/tasks/update-release-channel.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: $(params.ci-cluster-secret-name)
-              key: token
+              key: ci-prow-token
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
The key `token` inside of the secret `okd-prow-sa-auth` was wrong because it was changed to `ci-prow-token` in PR #10 