### PR TITLE
fix: issue on oc adm release new

### DIFF
--- a/base/tekton.dev/tasks/mirror-release.yaml
+++ b/base/tekton.dev/tasks/mirror-release.yaml
@@ -49,7 +49,9 @@ spec:
           --from-release "$RELEASE" \
           --mirror "$(params.content-mirror-pushspec)" \
           --to-image "$RELEASE_MIRROR" \
-          --name="$RELEASE_NAME"
+          --name="$RELEASE_NAME" \
+          --keep-manifest-list=true
+          
 
         printf "%s" "$RELEASE_MIRROR" > $(results.mirrored-pullspec.path)
       volumeMounts:


### PR DESCRIPTION
oc adm release new is failing because manifest lists were added to all images. 

The temporary fix is to add the flag keep-manifest-list=true in order to be able to do the OKD release