### PR TITLE
FDN-525: changing the .next, stable and pick release digest

### DIFF
--- a/base/tekton.dev/tasks/mirror-release.yaml
+++ b/base/tekton.dev/tasks/mirror-release.yaml
@@ -18,7 +18,7 @@ spec:
     - description: The URL for the GPG public key to use for verification
       name: gpg-public-key-url
       type: string
-      default: "https://raw.githubusercontent.com/openshift/cluster-update-keys/master/keys/verifier-public-key-openshift-ci-2"
+      default: "https://raw.githubusercontent.com/openshift/cluster-update-keys/master/keys/verifier-public-key-openshift-ci-3"
     - description: The content mirror destination
       name: content-mirror-pushspec
       type: string

--- a/base/tekton.dev/tasks/pick-release.yaml
+++ b/base/tekton.dev/tasks/pick-release.yaml
@@ -29,7 +29,7 @@ spec:
 
         RELEASE_NAME="$(echo "$RELEASE" | jq -r '.name')"
         RELEASE_PULLSPEC="$(echo "$RELEASE" | jq -r '.pullSpec')"
-        DIGEST="$(oc adm release info --output=jsonpath='{.digest}' "$RELEASE_PULLSPEC")"
+        DIGEST="$(oc adm release info --output=jsonpath='{.listDigest}' "$RELEASE_PULLSPEC")"
 
         # Use printf instead of echo so we don't end up with newlines.
         printf "%s" "$RELEASE_NAME" > $(results.release-name.path)

--- a/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
@@ -25,7 +25,7 @@ spec:
   - name: release-mirror-pushspec
     value: quay.io/okd/scos-release
   - name: release-stream
-    value: 4.14.0-0.okd-scos
+    value: 4.15.0-0.okd-scos
   podTemplate:
     nodeSelector:
       kubernetes.io/hostname: host-192-168-111-72

--- a/environments/moc/pipelineruns/okd-release-stable-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-release-stable-pipelinerun.yaml
@@ -25,7 +25,7 @@ spec:
   - name: release-mirror-pushspec
     value: quay.io/okd/scos-release
   - name: release-stream
-    value: 4.13.0-0.okd-scos
+    value: 4.14.0-0.okd-scos
   podTemplate:
     nodeSelector:
       kubernetes.io/hostname: host-192-168-111-72


### PR DESCRIPTION
This PR changes the version of the OKD releases for:

.Next = 4.15.0-0.okd-scos
stable = 4.14.0-0.okd-scos

It also update the pick-release task to get the digest of the manifest-list instead of the digest of a single manifest. This was necessary since the signature process is happening on the manifest-list level now.