### PR TITLE
Create releases within okd-project/okd instead of okd-project/okd-scos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 1. create or update the following secrets:
 * `okd-githubapp-auth`
-  * contains key `private.key`, which is private key of GitHub App (okd-tekton-token) with permissions to create releases in `okd-scos` project
+  * contains key `private.key`, which is private key of GitHub App (okd-tekton-token) with permissions to create releases in `okd` project
 * `okd-quay-pull-secret`, which is a dockerconfig with permissions to push to `quay.io/okd/scos-release` and `quay.io/okd/scos-content`
 * `okd-release-gpg-signing-key`
   * contains key `private.key`, which is the GPG key used to sign the OKD release
@@ -33,7 +33,7 @@ oc create -f environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
 ## Annex - running a task individually
 ```bash
 tkn task start create-github-release \
-  --param github-org-repo="okd-project/okd-scos" \
+  --param github-org-repo="okd-project/okd" \
   --param github-token-secret-key="gh-okd-token" \
   --param github-token-secret-name="gh-token" \
   --param gpg-key-id="maintainers@okd.io" \

--- a/base/tekton.dev/tasks/docs/get-github-access-token.md
+++ b/base/tekton.dev/tasks/docs/get-github-access-token.md
@@ -53,11 +53,11 @@ After the creation of the GitHub App, it is possible to install it in the organi
     1.1 Install it on okd-project
 ![](assets/install_1.1.png)
 
-2. Select only the repos where the GitHub App (okd-tekton-token) is needed. In this use case okd-project/okd-scos repo is selected and after that click on <kbd>Install</kbd> 
+2. Select only the repos where the GitHub App (okd-tekton-token) is needed. In this use case okd-project/okd repo is selected and after that click on <kbd>Install</kbd> 
 ![](assets/install_2.png)
 
 
-At this point the GitHub App (okd-tekton-token) is installed in the repo **okd-scos**. This GitHub App will be able to deliver token when requested by an external app.
+At this point the GitHub App (okd-tekton-token) is installed in the repo **okd**. This GitHub App will be able to deliver token when requested by an external app.
 
 ## New Tekton Task
 This sections shows the tekton task created to retrieve an access token calling the GitHub App created in the previous steps. Also, it shows the parameters required by this tekton task.

--- a/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
@@ -9,7 +9,7 @@ spec:
   - name: enable-notifications
     value: "true"
   - name: github-org-repo
-    value: okd-project/okd-scos
+    value: okd-project/okd
   - name: is-release-latest
     value: "false"
   - name: matrix-endpoint

--- a/environments/moc/pipelineruns/okd-release-stable-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-release-stable-pipelinerun.yaml
@@ -9,7 +9,7 @@ spec:
   - name: enable-notifications
     value: "true"
   - name: github-org-repo
-    value: okd-project/okd-scos
+    value: okd-project/okd
   - name: is-release-latest
     value: "true"
   - name: matrix-endpoint


### PR DESCRIPTION
Given we will only be releasing OKD SCOS builds for now it makes sense that the releases feature in the main `okd` repository (and I will be suggesting to archive the `okd-scos` repo).

I have updated the `okd-tekton-token` app with the same access to the `okd` project as it does `okd-scos` so the pipeline should now have permission.
