### PR TITLE
fix: last_release_name

### DIFF
--- a/base/tekton.dev/tasks/pick-target-release-name.yaml
+++ b/base/tekton.dev/tasks/pick-target-release-name.yaml
@@ -55,7 +55,7 @@ spec:
         else
             oc login --token="$CI_CLUSTER_TOKEN" --server="$(params.ci-cluster)"
             oc project "$(params.oc-project)"
-            LAST_RELEASE_NAME="$(oc get is "$(params.release-imagestream)" -ojson| jq '.status.tags[-1].tag')"
+            LAST_RELEASE_NAME="$(oc get is "$(params.release-imagestream)" -ojson| jq '.status.tags | sort_by(.items[0].created) | last.tag')"
         fi
 
         OKD_VERSION=$(echo "$(params.picked-release-name)" | cut -d '-' -f 1)


### PR DESCRIPTION
<img width="1898" height="263" alt="image" src="https://github.com/user-attachments/assets/1f8952d8-f835-49bb-a87f-b2dfe1d85eda" />


Fixing issue "a release with the same tag name already exists" affecting OKD promotions tekton pipeline.

Issue: LAST_RELEASE_NAME is fetched as last index from **image stream**: release-scos-next
It isn't always sorted by name of the tags.

Solution: Sorting the tags, and picking last tag as LAST_RELEASE_NAME.


After fix: 
<img width="1898" height="264" alt="image" src="https://github.com/user-attachments/assets/20912513-79e1-4476-984d-b6cf5396dc60" />
