### PR TITLE
Fix: Fixed curl filtering for cincinnati

### DIFF
--- a/base/tekton.dev/tasks/mirror-release.yaml
+++ b/base/tekton.dev/tasks/mirror-release.yaml
@@ -48,7 +48,7 @@ spec:
         curl -Lv "$(params.gpg-public-key-url)" | gpg --import
 
         # Grab all of the previous releases for cincinnati
-        ALL_RELEASES="$(curl https://amd64.origin.releases.ci.openshift.org/api/v1/releasestreams/accepted | jq -r ".["$(RELEASE_STREAM)"][]")"
+        ALL_RELEASES="$(curl https://amd64.origin.releases.ci.openshift.org/api/v1/releasestreams/accepted | jq -r ".[\"${RELEASE_STREAM}\"][]")"
 
         # Get the current major.minor version i.e. 4.19.x-okd-scos.x turns to 4.19
         CURRENT_MAJOR_MINOR="$(echo "$RELEASE_NAME" | cut -d. -f1-2)"


### PR DESCRIPTION
There was an issue with pulling releases. This PR is to fix that bug.