### PR TITLE
Resolve Tekton scheduling failures, harden task env, and update release streams

### DIFF
--- a/base/tekton.dev/tasks/mirror-release.yaml
+++ b/base/tekton.dev/tasks/mirror-release.yaml
@@ -54,36 +54,40 @@ spec:
 
         # Grab all of the previous accapted releases for cincinnati
         ACCEPTED_STREAMS="$(curl -s https://amd64.origin.releases.ci.openshift.org/api/v1/releasestreams/accepted)"
-        ALL_RELEASES="$(echo "$ACCEPTED_STREAMS" | jq -r ".[\"${TARGET_RELEASE_STREAM}\"][]")"
+        ALL_RELEASES="$(echo "$ACCEPTED_STREAMS" | jq -r ".[\"${TARGET_RELEASE_STREAM}\"] // [] | .[]")"
 
-        # Get the current major.minor version i.e. 4.19.x-okd-scos.x turns to 4.19
-        CURRENT_MAJOR_MINOR="$(echo "$RELEASE_NAME" | cut -d. -f1-2)"
-        CURRENT_MAJOR="$(echo "$CURRENT_MAJOR_MINOR" | cut -d. -f1)"
-        CURRENT_MINOR="$(echo "$CURRENT_MAJOR_MINOR" | cut -d. -f2)"
+        PREVIOUS_FLAG=""
+        if [[ -n "$ALL_RELEASES" ]]; then
+          # Get the current major.minor version i.e. 4.19.x-okd-scos.x turns to 4.19
+          CURRENT_MAJOR_MINOR="$(echo "$RELEASE_NAME" | cut -d. -f1-2)"
+          CURRENT_MAJOR="$(echo "$CURRENT_MAJOR_MINOR" | cut -d. -f1)"
+          CURRENT_MINOR="$(echo "$CURRENT_MAJOR_MINOR" | cut -d. -f2)"
 
-        # When minor is 0 (e.g. 5.0), simple subtraction produces -1.
-        # Instead, find the highest minor from the previous major in accepted streams.
-        if [[ "$CURRENT_MINOR" -eq 0 ]]; then
-          PREV_MAJOR="$((CURRENT_MAJOR - 1))"
-          PREV_MAJOR_MINOR="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR}\." | cut -d. -f1-2 | sort -t. -k2 -n | tail -n 1)"
+          # When minor is 0 (e.g. 5.0), simple subtraction produces -1.
+          # Instead, find the highest minor from the previous major in accepted streams.
+          if [[ "$CURRENT_MINOR" -eq 0 ]]; then
+            PREV_MAJOR="$((CURRENT_MAJOR - 1))"
+            PREV_MAJOR_MINOR="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR}\." | cut -d. -f1-2 | sort -t. -k2 -n | tail -n 1)"
+          else
+            PREV_MINOR="$((CURRENT_MINOR - 1))"
+            PREV_MAJOR_MINOR="${CURRENT_MAJOR}.${PREV_MINOR}"
+          fi
+
+          # Get the last 1 previous major.minor releases
+          PREV_RELEASES="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR_MINOR}\." | head -n 1)"
+
+          # Get all current major.minor releases and combine them
+          CURRENT_RELEASES="$(echo "$ALL_RELEASES" | grep "^${CURRENT_MAJOR_MINOR}\.")"
+          FILTERED_RELEASES=$(echo -e "$PREV_RELEASES\n$CURRENT_RELEASES" | grep -v '^$')
+
+          # Convert the filtered releases to a comma-separated string
+          PREVIOUS_RELEASES=$(echo "$FILTERED_RELEASES" | tr '\n' ',' | sed 's/,$//')
+
+          if [[ -n "$PREVIOUS_RELEASES" ]]; then
+            PREVIOUS_FLAG="--previous=$PREVIOUS_RELEASES"
+          fi
         else
-          PREV_MINOR="$((CURRENT_MINOR - 1))"
-          PREV_MAJOR_MINOR="${CURRENT_MAJOR}.${PREV_MINOR}"
-        fi
-
-        # Get the last 1 previous major.minor releases
-        PREV_RELEASES="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR_MINOR}\." | head -n 1)"
-
-        # Get all current major.minor releases and combine them
-        CURRENT_RELEASES="$(echo "$ALL_RELEASES" | grep "^${CURRENT_MAJOR_MINOR}\.")"
-        FILTERED_RELEASES=$(echo -e "$PREV_RELEASES\n$CURRENT_RELEASES" | grep -v '^$')
-
-        # Convert the filtered releases to a comma-separated string
-        PREVIOUS_RELEASES=$(echo "$FILTERED_RELEASES" | tr '\n' ',' | sed 's/,$//')
-
-        # check if the filtered releases is empty or it's not a valid comma-separated string
-        if ! echo "$PREVIOUS_RELEASES" | grep -q ','; then
-          echo "PREVIOUS_RELEASES is not a valid comma-separated string"
+          echo "No accepted releases found for stream ${TARGET_RELEASE_STREAM}, proceeding without --previous"
         fi
 
         oc adm release new \
@@ -94,7 +98,7 @@ spec:
           --to-image "$RELEASE_MIRROR" \
           --name="$RELEASE_NAME" \
           --keep-manifest-list=true \
-          --previous="$PREVIOUS_RELEASES"
+          ${PREVIOUS_FLAG:+"$PREVIOUS_FLAG"}
 
         printf "%s" "$RELEASE_MIRROR" > $(results.mirrored-pullspec.path)
       volumeMounts:

--- a/base/tekton.dev/tasks/pick-target-release-name.yaml
+++ b/base/tekton.dev/tasks/pick-target-release-name.yaml
@@ -101,6 +101,14 @@ spec:
             fi
             RELEASE_NAME="$OKD_VERSION$suffix"
             printf "%s" "$RELEASE_NAME" > $(results.target-release-name.path)
+        elif [[ -z "$LAST_RELEASE_NAME" || "$LAST_RELEASE_NAME" == "null" ]]; then
+            if [[ "$(params.release-imagestream)" == *"next" ]]; then
+                suffix="-okd-scos.ec.0"
+            else
+                suffix="-okd-scos.0"
+            fi
+            RELEASE_NAME="$OKD_VERSION$suffix"
+            printf "%s" "$RELEASE_NAME" > $(results.target-release-name.path)
         else
             echo "No previous release found!"
         fi

--- a/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
+++ b/environments/moc/pipelineruns/okd-release-next-pipelinerun.yaml
@@ -21,7 +21,7 @@ spec:
   - name: release-controller
     value: https://origin-release.ci.openshift.org
   - name: release-imagestream
-    value: release-scos-next
+    value: release-5-scos-next
   - name: release-mirror-pushspec
     value: quay.io/okd/scos-release
   - name: release-stream


### PR DESCRIPTION
## Summary

- **Remove hardcoded `podTemplate.nodeSelector`** from PipelineRun manifests — PV nodeAffinity and Tekton affinity assistants handle placement for workspace-backed tasks, while non-PVC tasks can schedule on any worker.
- **Set `HOME=/tekton/home`** (and `GNUPGHOME` where GPG is used) on all task steps so tools like `oc`, `gpg`, and `gh` write to a writable directory under restricted SCCs (Tekton v1.6+).
- **Strip `spec.podTemplate`** from fetched PipelineRun YAML in the promotion task before applying, preventing upstream bare-metal hostnames from breaking other clusters.
- **Fix `mirror-release` Cincinnati lookups** — use `target-release-stream` instead of `release-stream`, cache accepted-streams response, add safe fallback for 5.0 (minor=0) previous-version resolution, and guard against empty results.
- **Fix `pick-target-release-name` stable logic** — query all release tags and find the highest numbered release instead of relying on the latest-accepted endpoint (which skips rejected releases). Add first-release bootstrapping for new streams.
- **Update release streams** — stable stream now targets 4.22, next stream moves to `5-scos-next` / `5.0`.
- **Migrate `kustomization.yaml`** from deprecated `bases` to `resources`.
- **Expand ClusterRole** with `nodes get/list` and `clustertriggerbindings` permissions.
- **Add `scripts/cleanup-stuck-release-pipelinerun.sh`** utility for tearing down stuck PipelineRuns and affinity assistants.

## Test Plan

- [x] Trigger `okd-release-next-pipelinerun` and verify it schedules without node-selector errors
- [x] Trigger `okd-release-stable-pipelinerun` and confirm `pick-target-release-name` correctly resolves the highest existing release
- [x] Verify `mirror-release` builds the correct `--previous` flag (including the 5.0 cross-major edge case)
- [x] Confirm promotion CronJob strips `podTemplate` before applying PipelineRuns
- [x] Validate `kustomize build environments/moc/` produces correct output