### PR TITLE
Fix cross-major-version release lookup and make scripts portable across macOS/Linux

### DIFF
--- a/base/tekton.dev/tasks/mirror-release.yaml
+++ b/base/tekton.dev/tasks/mirror-release.yaml
@@ -64,17 +64,18 @@ spec:
           CURRENT_MINOR="$(echo "$CURRENT_MAJOR_MINOR" | cut -d. -f2)"
 
           # When minor is 0 (e.g. 5.0), simple subtraction produces -1.
-          # Instead, find the highest minor from the previous major in accepted streams.
+          # Instead, find the highest minor from the previous major's stream.
           if [[ "$CURRENT_MINOR" -eq 0 ]]; then
             PREV_MAJOR="$((CURRENT_MAJOR - 1))"
-            PREV_MAJOR_MINOR="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR}\." | cut -d. -f1-2 | sort -t. -k2 -n | tail -n 1)"
+            PREV_STREAM="$(echo "$TARGET_RELEASE_STREAM" | sed "s/^${CURRENT_MAJOR}/${PREV_MAJOR}/")"
+            PREV_STREAM_RELEASES="$(echo "$ACCEPTED_STREAMS" | jq -r ".[\"${PREV_STREAM}\"] // [] | .[]")"
+            PREV_MAJOR_MINOR="$(echo "$PREV_STREAM_RELEASES" | cut -d. -f1-2 | sort -t. -k2 -n | tail -n 1)"
+            PREV_RELEASES="$(echo "$PREV_STREAM_RELEASES" | grep "^${PREV_MAJOR_MINOR}\." | head -n 1)"
           else
             PREV_MINOR="$((CURRENT_MINOR - 1))"
             PREV_MAJOR_MINOR="${CURRENT_MAJOR}.${PREV_MINOR}"
+            PREV_RELEASES="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR_MINOR}\." | head -n 1)"
           fi
-
-          # Get the last 1 previous major.minor releases
-          PREV_RELEASES="$(echo "$ALL_RELEASES" | grep "^${PREV_MAJOR_MINOR}\." | head -n 1)"
 
           # Get all current major.minor releases and combine them
           CURRENT_RELEASES="$(echo "$ALL_RELEASES" | grep "^${CURRENT_MAJOR_MINOR}\.")"

--- a/scripts/cleanup-stuck-release-pipelinerun.sh
+++ b/scripts/cleanup-stuck-release-pipelinerun.sh
@@ -16,7 +16,10 @@ pr_delete_args=()
 if [[ $# -ge 1 ]]; then
   pr_delete_args=("$1")
 else
-  mapfile -t pr_delete_args < <(oc get pipelineruns.tekton.dev -n "${NS}" -l tekton.dev/pipeline=okd-release-pipeline -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+  pr_delete_args=()
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] && pr_delete_args+=("$line")
+  done < <(oc get pipelineruns.tekton.dev -n "${NS}" -l tekton.dev/pipeline=okd-release-pipeline -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
 fi
 
 for pr in "${pr_delete_args[@]}"; do

--- a/scripts/setup-okd-release-pipeline.sh
+++ b/scripts/setup-okd-release-pipeline.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="okd-coreos"
 
+sed_inplace() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
 echo "=========================================="
 echo "OKD Release Pipeline Setup Script"
 echo "=========================================="
@@ -37,9 +45,8 @@ echo "[2/8] Updating node selectors in PV and PipelineRun files..."
 for pv_file in "$SCRIPT_DIR/okd-release-pipeline/base/core/persistentvolumes/pipeline-release-"*"-pv.yaml"; do
     if [[ -f "$pv_file" ]]; then
         # Match any existing worker node pattern and replace
-        sed -i -E "s/- [a-zA-Z0-9_-]+-worker-[a-zA-Z0-9-]+/- $WORKER_NODE/" "$pv_file"
-        # Also handle simpler patterns like host-xxx
-        sed -i -E "s/- host-[0-9-]+/- $WORKER_NODE/" "$pv_file"
+        sed_inplace -E "s/- [a-zA-Z0-9_-]+-worker-[a-zA-Z0-9-]+/- $WORKER_NODE/" "$pv_file"
+        sed_inplace -E "s/- host-[0-9-]+/- $WORKER_NODE/" "$pv_file"
         echo "  Updated: $pv_file"
     fi
 done
@@ -47,7 +54,7 @@ done
 # Update PipelineRuns
 for pr_file in "$SCRIPT_DIR/okd-release-pipeline/environments/moc/pipelineruns/"*.yaml; do
     if [[ -f "$pr_file" ]]; then
-        sed -i "s/kubernetes.io\/hostname: .*/kubernetes.io\/hostname: $WORKER_NODE/" "$pr_file"
+        sed_inplace "s/kubernetes.io\/hostname: .*/kubernetes.io\/hostname: $WORKER_NODE/" "$pr_file"
         echo "  Updated: $pr_file"
     fi
 done


### PR DESCRIPTION
## Summary
- **Fix previous-release lookup when crossing major version boundary**: When current minor is 0 (e.g. 5.0), the previous major's releases live in a different stream. The mirror-release task now looks up the correct previous stream from `ACCEPTED_STREAMS` by name instead of searching `ALL_RELEASES`.
- **Make shell scripts portable across macOS and Linux**: Replace `mapfile` (Bash 4+ only) with a `while read` loop for macOS Bash 3.2 compatibility, and add a `sed_inplace` wrapper to handle BSD sed vs GNU sed in-place editing differences.

## Test plan
- [ ] Verify `cleanup-stuck-release-pipelinerun.sh` runs on macOS (Bash 3.2) and Linux
- [ ] Verify `setup-okd-release-pipeline.sh` sed replacements work on both macOS and Linux
- [ ] Verify mirror-release task correctly resolves previous releases when minor is 0 (e.g. 5.0 → 4.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)